### PR TITLE
Fix for issue #4

### DIFF
--- a/plugin/intim.vim
+++ b/plugin/intim.vim
@@ -638,7 +638,7 @@ function! s:LaunchSession() "{{{
     else
         " build the launching command: term -e 'tmux new -s sname' &
         let launchCommand = s:terminal()
-                    \ . " -e 'tmux -2 new -s " . s:sname() . "' &;"
+	            \ . " -- tmux -2 new -s " . s:sname() . " &"
         " send the command
         call s:System(launchCommand)
         " + send additionnal command if user needs it


### PR DESCRIPTION
The semicolon at the end of the command is invalid syntax in Bourne shells such as bash.
Using the -- sytnax for the tmux command suppresses a warning raised by -e.
@iago-lito I've only tested the changes in bash, what shell do you use?